### PR TITLE
优化: 修复页面左侧出现多余1px白色边框的错误

### DIFF
--- a/src/components/Header/component/SidebarNav/index.tsx
+++ b/src/components/Header/component/SidebarNav/index.tsx
@@ -13,7 +13,7 @@ export default ({ list, open, onClose }: Props) => {
   return (
     <>
       <div className={`flex fixed top-0 left-0 ${open ? 'w-full' : 'w-0'} h-full z-[60] transition-width`}>
-        <div className={`overflow-auto ${open ? 'w-8/12 p-5' : 'w-0'} border-r dark:border-[#2b333e] bg-[rgba(255,255,255,0.9)] dark:bg-[rgba(44,51,62,0.9)] backdrop-blur-[5px] transition-width hide_sliding`}>
+        <div className={`overflow-auto ${open ? 'w-8/12 p-5' : 'w-0'} dark:border-[#2b333e] bg-[rgba(255,255,255,0.9)] dark:bg-[rgba(44,51,62,0.9)] backdrop-blur-[5px] transition-width hide_sliding`}>
           <ul className="flex flex-col space-y-2">
             {list?.map(one => (
               <li key={one.id} className="group/one relative hover:bg-[#e0e6ec] dark:hover:bg-[#495362] rounded-md transition-colors">


### PR DESCRIPTION
# 一、问题描述：
原页面左侧会显示一个无用的1px白色边框，在Swiper组件中明显可见

# 二、修复预览
## 2.1 原始：
![页面左侧出现1px白色边框](https://github.com/user-attachments/assets/d00ac44f-a80b-416b-869a-e4f51b6e7ced)
该白色边框在显示深色图片的Swiper组件区域内明显可见

![页面左侧出现1px白色边框](https://github.com/user-attachments/assets/4cc632c0-1017-4d4a-ae79-74a5edcd39a0)
在开发者工具的边框盒子模型中显示有一个1px右边框

## 2.2 修复后：
![修复后](https://github.com/user-attachments/assets/d2d0e08a-aa25-40a7-8c3d-fe8d0e59b22c)
修复后正常
