### PR TITLE
添加文章摘要组件及样式，展示文章内容摘要和相关建议

### DIFF
--- a/src/app/article/[id]/page.tsx
+++ b/src/app/article/[id]/page.tsx
@@ -8,6 +8,7 @@ import Copyright from "../components/Copyright";
 import UpAndDown from "../components/UpAndDown";
 import Comment from "../components/Comment";
 import MD from "../components/MD";
+import Summary from "../components/Summary";
 import Nav from "../components/Nav";
 
 import { IoMdPricetags } from "react-icons/io";
@@ -84,6 +85,7 @@ export default async (props: Props) => {
                     </Slide>
 
                     <div className="w-[90%] xl:w-6/12 mx-auto mt-12 relative">
+                        <Summary content={data?.description || ""} />
                         <MD data={data?.content} />
 
                         <div className="w-full">

--- a/src/app/article/components/Summary/index.scss
+++ b/src/app/article/components/Summary/index.scss
@@ -1,0 +1,118 @@
+.post-ai {
+  border-radius: 12px;
+  padding: 12px;
+  border: 1px solid;
+  margin: 8px 0 16px;
+  transition: all 0.3s ease;
+
+  :root & {
+    background: #f1f3f8;
+    border-color: #e3e8f7;
+  }
+
+  .dark & {
+    background: #21232a;
+    border-color: #3d3d3f;
+  }
+}
+
+.ai-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.ai-title-left {
+  display: flex;
+  align-items: center;
+}
+
+.ai-title-text {
+  font-weight: bold;
+}
+
+.ai-tag {
+  padding: 2px 8px;
+  border-radius: 8px;
+  font-size: 12px;
+
+  :root & {
+    background: rgba(42, 148, 225, 0.1);
+    color: #2a94e1;
+  }
+
+  .dark & {
+    background: rgba(42, 148, 225, 0.2);
+    color: #5a9cf8;
+  }
+}
+
+.ai-explanation {
+  line-height: 1.5;
+  position: relative;
+
+  :root & {
+    color: #a1a2b8;
+  }
+
+  .dark & {
+    color: #8a8b9c;
+  }
+}
+
+.cursor {
+  animation: blink 1s step-end infinite;
+
+  :root & {
+    color: #2a94e1;
+  }
+
+  .dark & {
+    color: #5a9cf8;
+  }
+}
+
+.ai-suggestions {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ai-suggestions-item {
+  padding: 8px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+
+  :root & {
+    background: rgba(42, 148, 225, 0.1);
+    color: #2a94e1;
+  }
+
+  .dark & {
+    background: rgba(42, 148, 225, 0.2);
+    color: #5a9cf8;
+  }
+
+  &:hover {
+    :root & {
+      background: rgba(42, 148, 225, 0.2);
+    }
+
+    .dark & {
+      background: rgba(42, 148, 225, 0.3);
+    }
+  }
+}
+
+@keyframes blink {
+  from,
+  to {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}

--- a/src/app/article/components/Summary/index.tsx
+++ b/src/app/article/components/Summary/index.tsx
@@ -1,0 +1,68 @@
+"use client";
+import { useEffect, useState } from "react";
+import "./index.scss";
+
+interface SummaryProps {
+  content: string;
+}
+
+const suggestions = [
+  "谁是刘宇阳？",
+  "这篇文章讲了什么？",
+  "带我去看看其他文章",
+];
+
+export default function Summary({ content }: SummaryProps) {
+  const [displayText, setDisplayText] = useState("");
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
+  const handleThriveGPTClick = () => {
+    // TODO: 调用逻辑
+  };
+
+  useEffect(() => {
+    if (currentIndex < content.length) {
+      const timeout = setTimeout(() => {
+        setDisplayText((prev) => prev + content[currentIndex]);
+        setCurrentIndex((prev) => prev + 1);
+      }, 20);
+      return () => clearTimeout(timeout);
+    }
+  }, [currentIndex, content]);
+
+  return (
+    <div className="post-ai" data-nosnippet="">
+      <div className="ai-title">
+        <div className="ai-title-left">
+          <div className="ai-title-text">文章摘要</div>
+        </div>
+        <div
+          className="ai-tag"
+          id="ai-tag"
+          title="了解助理"
+          onClick={handleThriveGPTClick} // TODO: 实现后完善交互逻辑
+        >
+          ThriveGPT
+        </div>
+      </div>
+      <div className="ai-explanation">
+        {displayText}
+        {currentIndex < content.length && <span className="cursor">|</span>}
+      </div>
+      {showSuggestions && (
+        <div className="ai-suggestions">
+          {suggestions.map((item, index) => (
+            <div
+              key={index}
+              className="ai-suggestions-item"
+              // TODO: 添加点击处理逻辑
+            >
+              {item}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
变更内容
- 新增文章摘要展示组件
- 交互式建议面板（TODO）

实现细节
- 展现的是控制端中文章创作时用助理生成文章简介

截图如下
![image](https://github.com/user-attachments/assets/a156f79f-26ab-40fe-9e02-bb6c3cc6e0bb)


待完成事项：
- 实现 ThriveGPT 点击事件处理
- 添加建议项的点击交互
- 接入 API 实现动态建议内容