### PR TITLE
fix: 将无效的 'easings' 替换为 'ease' 以进行成帧运动过渡

### DIFF
--- a/src/app/data/components/Archiving/index.tsx
+++ b/src/app/data/components/Archiving/index.tsx
@@ -101,7 +101,7 @@ export default ({ list }: { list: Article[] }) => {
                                                     duration: 1,
                                                 },
                                                 opacity: {
-                                                    easings: "ease",
+                                                    ease: "easeInOut",
                                                     duration: 1,
                                                 },
                                             },
@@ -112,11 +112,11 @@ export default ({ list }: { list: Article[] }) => {
                                             height: 0,
                                             transition: {
                                                 height: {
-                                                    easings: "ease",
+                                                    ease: "easeInOut",
                                                     duration: 0.25,
                                                 },
                                                 opacity: {
-                                                    easings: "ease",
+                                                    ease: "easeInOut",
                                                     duration: 0.3,
                                                 },
                                             },


### PR DESCRIPTION
**🐛 Bug Fix**

此PR修复了在成帧运动转换中使用无效的 “easings” 键导致的编译错误。

✅根据成帧器动作类型，用有效的 “ease” 键替换 “easings”。